### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
 	"version": "0.1.1",
 	"main": "src/index.js",
 	"scripts": {
-		"start": "node ."
+		"start": "node .",
+		"install": "yarn add discord.js dotenv moment",
+		"test": "mocha"
 	},
 	"homepage": "https://github.com/Tougrel/Galaxy-Commander",
 	"repository": "https://github.com/Tougrel/galaxy-commander.git",
@@ -24,6 +26,7 @@
 	"dependencies": {
 		"discord.js": "^12.5.1",
 		"dotenv": "^8.2.0",
-		"moment": "^2.29.1"
+		"moment": "^2.29.1",
+		"mocha": "^8.3.2"
 	}
 }


### PR DESCRIPTION
pre-15.x tests don't fail because they ignore that there is no actual test being performed, as it has not been specified.
15.x requires you specify a test, and thus it fails

i've made it so you actually perform the tests